### PR TITLE
Flask support for flask>=2.2.5,<4.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "pyproject.toml"
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Get tox environments
@@ -37,6 +39,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "pyproject.toml"
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     types:
       - opened
       - synchronize
+  workflow_dispatch:
 
 jobs:
   generate-matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,43 +10,35 @@ on:
       - synchronize
 
 jobs:
-  lint:
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      tox-envs: ${{ steps.set-envs.outputs.tox-envs }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.13"
       - name: Install tox
         run: uv tool install tox --with tox-uv
-      - name: Lint
-        run: tox -e lint
+      - name: Get tox environments
+        id: set-envs
+        run: |
+          ENVS=$(tox -l | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "tox-envs=$ENVS" >> $GITHUB_OUTPUT
 
   test:
+    needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - python-version: "3.13"
-            tox-env: "py313"
-          - python-version: "3.12"
-            tox-env: "py312"
-          - python-version: "3.11"
-            tox-env: "py311"
-          - python-version: "3.10"
-            tox-env: "py310"
-          - python-version: "3.9"
-            tox-env: "py39"
-          - python-version: "3.8"
-            tox-env: "py38"
+        tox-env: ${{ fromJson(needs.generate-matrix.outputs.tox-envs) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Test
         run: tox -e ${{ matrix.tox-env }}
+        env:
+          UV_PYTHON_DOWNLOADS: auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "flask>=2.2.5,<3.0.0",
+    "flask>=2.2.5,<4.0.0",
     "typing_extensions>=4.7.1,<5",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py38, py39, py310, py311, py312, py313
+envlist = lint, py{38,39,310,311,312,313}-{flask2,flask3}
 
 [testenv:lint]
 skip_install = true
@@ -20,5 +20,7 @@ deps =
     pytest-cov>=5.0.0
     fastapi>=0.111.0
     starlette>=0.37.2
+    flask2: flask>=2.2.5,<3.0.0
+    flask3: flask>=3.0.0,<4.0.0
 commands =
     pytest --cov=vellox --cov-fail-under=90 --cov-report=term-missing {posargs}


### PR DESCRIPTION
flask has a vulnerability in the version 2.2.5, which was only fixed in 3.1.3, so vellox need to support flask <4.0.0

- `pyproject.toml`: added upgraded flask version to pyproject.toml
-  `.github/workflows/test.yml`: every tox environment gets automatically read from tox.ini and the correct python version installed -> so no changes needed, when new environments get added
- `.github/workflows/test.yml`: added workflow dispatch, so the tests can be started, without a new commit
- `tox.ini` added new environments to test with both `flask>=2.2.5,<3.0.0` and `flask>=3.0.0,<4.0.0`

Output of pip-audit or uv-audit
```
Found 1 known vulnerabilities in 1 packages
Name   Version  ID                   Fix Versions  Link                                             
-----  -------  -------------------  ------------  -------------------------------------------------
flask  2.2.5    GHSA-68rp-wp8r-4726  3.1.3         https://osv.dev/vulnerability/GHSA-68rp-wp8r-4726
Vulnerabilites found
```
